### PR TITLE
Should we tweak the default archive templates regarding Microformats?

### DIFF
--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -10,14 +10,16 @@
 	{{ end }}
 	
 	{{ $list := (where .Site.Pages "Type" "post") }}
-	{{ range $list }}
-
-		<p class="h-entry">
-			<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>:
-			<span class="p-name"><b>{{ .Title }}</b></span> 
-			<span class="p-summary">{{ .Summary | truncate 100 }}</span>
-		</p>
-
-	{{ end }}
+	<div class="h-feed">
+		{{ range $list }}
+	
+			<p class="h-entry">
+				<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>:
+				<span class="p-name"><b>{{ .Title }}</b></span> 
+				<span class="p-summary">{{ .Summary | truncate 100 }}</span>
+			</p>
+			
+		{{ end }}
+	</div>
 
 {{ end }}

--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -14,7 +14,7 @@
 		{{ range $list }}
 	
 			<p class="h-entry">
-				<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>:
+				<a href="{{ .Permalink }}" class="u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</time></a>:
 				{{ if .Title }}
 					<span class="p-name"><b>{{ .Title }}</b></span> 
 				{{ end }}

--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -15,7 +15,9 @@
 	
 			<p class="h-entry">
 				<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>:
-				<span class="p-name"><b>{{ .Title }}</b></span> 
+				{{ if .Title }}
+					<span class="p-name"><b>{{ .Title }}</b></span> 
+				{{ end }}
 				<span class="p-summary">{{ .Summary | truncate 100 }}</span>
 			</p>
 			

--- a/layouts/list.archivehtml.html
+++ b/layouts/list.archivehtml.html
@@ -10,14 +10,16 @@
 	{{ end }}
 	
 	{{ $list := (where .Site.Pages "Type" "post") }}
-	{{ range $list }}
-
-		<p class="h-entry">
-			<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>:
-			<span class="p-name"><b>{{ .Title }}</b></span> 
-			<span class="p-summary">{{ .Summary | truncate 100 }}</span>
-		</p>
-
-	{{ end }}
+	<div class="h-feed">
+		{{ range $list }}
+	
+			<p class="h-entry">
+				<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>:
+				<span class="p-name"><b>{{ .Title }}</b></span> 
+				<span class="p-summary">{{ .Summary | truncate 100 }}</span>
+			</p>
+			
+		{{ end }}
+	</div>
 
 {{ end }}

--- a/layouts/list.archivehtml.html
+++ b/layouts/list.archivehtml.html
@@ -14,7 +14,7 @@
 		{{ range $list }}
 	
 			<p class="h-entry">
-				<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>:
+				<a href="{{ .Permalink }}" class="u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</time></a>:
 				{{ if .Title }}
 					<span class="p-name"><b>{{ .Title }}</b></span> 
 				{{ end }}

--- a/layouts/list.archivehtml.html
+++ b/layouts/list.archivehtml.html
@@ -15,7 +15,9 @@
 	
 			<p class="h-entry">
 				<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>:
-				<span class="p-name"><b>{{ .Title }}</b></span> 
+				{{ if .Title }}
+					<span class="p-name"><b>{{ .Title }}</b></span> 
+				{{ end }}
 				<span class="p-summary">{{ .Summary | truncate 100 }}</span>
 			</p>
 			


### PR DESCRIPTION
Hey @manton,

During my testing, I noticed three things with the default archive templates `list.archivehtml.html`:

- There's no `h-feed` present.
- Markup and Microformat for `p-name` is outputted even when there's no title.
- `datetime` is used on a `span` but needs a `time` element (or `ins` or `del`).

This pull request suggests how `h-feed` and a title check could be implemented and change from `span` to `time`.