### PR TITLE
Extract common Micro.blog head elements and make them compatible with Hugo 0.117

### DIFF
--- a/config.json
+++ b/config.json
@@ -56,11 +56,11 @@
 		"page": [ "HTML" ],
 		"section": [ "HTML" ],
 		"taxonomy": [ "HTML", "RSS", "JSON" ],
-		"taxonomyTerm": [ "HTML", "RSS", "JSON" ]
+		"term": [ "HTML", "RSS", "JSON" ]
 	},
 	"taxonomies": {
 		"category": "categories"
-	},	
+	},
 	"rssLimit": 25,
 	"uglyURLs": false,
 	"blackfriday": {

--- a/layouts/_default/list.json.json
+++ b/layouts/_default/list.json.json
@@ -1,0 +1,34 @@
+{
+  "version": "https://jsonfeed.org/version/1",
+  "title": {{ .Site.Title | jsonify }},
+  "icon": "{{ .Site.Author.avatar }}",
+  "home_page_url": "{{ .Site.BaseURL }}",
+  "feed_url": "{{ .Site.BaseURL }}feed.json",
+  "items": [
+    {{- $len := (len .Pages) -}}
+    {{ range $index, $value := .Pages }}
+      {
+        {{ if .Params.guid -}}
+        "id": "{{ .Params.guid }}",
+        {{- else -}}
+        "id": "{{ .Permalink }}",
+        {{- end }}
+        {{ if .Title -}}
+        "title": {{ .Title | jsonify }},
+        {{- end -}}
+        {{- $s := .Content | jsonify -}}
+        {{- $s := replace $s "\\u003c" "<" -}}
+        {{- $s := replace $s "\\u003e" ">" -}}
+        {{- $s := replace $s "\\u0026" "&" }}
+        "content_html": {{ $s }},
+        "date_published": "{{ .Date.Format "2006-01-02T15:04:05-07:00" }}",
+        "url": "{{ .Permalink }}"
+        {{- with .Params.categories -}}
+        ,
+        "tags": {{ . | jsonify }}
+        {{- end }}
+      }
+      {{- if ne (add $index 1) $len -}},{{- end -}}
+    {{ end }}
+  ]
+}

--- a/layouts/_default/list.json.json
+++ b/layouts/_default/list.json.json
@@ -1,6 +1,6 @@
 {
   "version": "https://jsonfeed.org/version/1",
-  "title": {{ .Site.Title | jsonify }},
+  "title": {{ if eq  .Title  .Site.Title }}{{ .Site.Title | jsonify }}{{ else }}{{ printf `%s on %s` .Title .Site.Title | jsonify }}{{ end }},
   "icon": "{{ .Site.Author.avatar }}",
   "home_page_url": "{{ .Site.BaseURL }}",
   "feed_url": "{{ .Site.BaseURL }}feed.json",

--- a/layouts/list.podcastjson.json
+++ b/layouts/list.podcastjson.json
@@ -16,7 +16,7 @@
 		]
 	},
 	"items": [
-		{{- $list := where .Site.Pages ".Params.audio" "!=" nil -}}
+		{{- $list := where .Site.Pages ".Params.audio_with_metadata" "!=" nil -}}
 		{{- $len := (len $list) -}}
 		{{ range $index, $value := $list }}
 			{
@@ -39,7 +39,7 @@
 				,
 				"tags": {{ . | jsonify }}
 				{{- end -}}
-				{{- range first 1 .Params.audio -}},
+				{{- range first 1 .Params.audio_with_metadata -}},
 				"attachments": [
 					{
 						"url": "{{ . }}",

--- a/layouts/newsletter.html
+++ b/layouts/newsletter.html
@@ -38,7 +38,7 @@
 		{{ .Content }}
 
 		<p>
-		{{ if gt (len .Params.audio) 0 }}
+		{{ if gt (len .Params.audio_with_metadata) 0 }}
 			<a href="{ .Permalink }">Audio</a>
 		{{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,1 @@
+{{ partial "microblog-head.html" . }}

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -4,10 +4,10 @@
 {{ $rsslink := .OutputFormats.Get "rss" }}
 {{ if $rsslink }}
   <link href="{{ $rsslink.Permalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
   <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
-  <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
 {{ end -}}
+
+<link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
 
 <link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
 
@@ -23,6 +23,7 @@
   <link rel="me" href="https://instagram.com/{{ . }}" />
 {{ end }}
 
+<link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
 <link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
 <link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
 <link rel="micropub" href="https://micro.blog/micropub" />

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -5,6 +5,7 @@
 {{ $podcastEpisodeCount := len (where .Site.Pages ".Params.audio" "!=" nil) }}
 {{ if gt $podcastEpisodeCount 0 }}
   <link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast">
+  <link rel="alternate" href="{{ "podcast.json" | absURL }}" type="application/application/json" title="Podcast">
 {{ end }}
 
 <link rel="me" href="https://micro.blog/{{ .Site.Author.username }}">

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -1,8 +1,9 @@
 <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
 <link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
 
-{{ if .RSSLink -}}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+{{ $rsslink := .OutputFormats.Get "rss" }}
+{{ if $rsslink }}
+  <link href="{{ $rsslink.Permalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
   <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
   <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
   <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -3,11 +3,11 @@
 
 {{ $rsslink := .OutputFormats.Get "rss" }}
 {{ if $rsslink }}
-  <link href="{{ $rsslink.Permalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
+  <link rel="alternate" href="{{ $rsslink.Permalink }}" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link rel="alternate" href="{{ "feed.json" | absURL }}" type="application/json" title="{{ .Site.Title }}" />
 {{ end -}}
 
-<link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
+<link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast" />
 
 <link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
 

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -1,3 +1,8 @@
+{{ if ne .Kind "home" }}
+  <link rel="alternate" href="{{ "feed.xml" | absURL }}" type="application/rss+xml" title="{{ $.Site.Title }}">
+  <link rel="alternate" href="{{ "feed.json" | absURL }}" type="application/json" title="{{ $.Site.Title }}">
+{{ end }}
+
 {{ range .AlternativeOutputFormats -}}
   {{ printf `<link rel="%s" href="%s" type="%s" title="%s">` .Rel .Permalink .MediaType.Type $.Site.Title | safeHTML }}
 {{ end -}}

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -1,0 +1,38 @@
+<link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
+<link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
+
+{{ if .RSSLink -}}
+  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
+  <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
+  <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
+{{ end -}}
+
+<link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
+
+{{ with .Site.Params.twitter_username }}
+  <link rel="me" href="https://twitter.com/{{ . }}" />
+{{ end }}
+
+{{ with .Site.Params.github_username }}
+  <link rel="me" href="https://github.com/{{ . }}" />
+{{ end }}
+
+{{ with .Site.Params.instagram_username }}
+  <link rel="me" href="https://instagram.com/{{ . }}" />
+{{ end }}
+
+<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
+<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
+<link rel="micropub" href="https://micro.blog/micropub" />
+<link rel="microsub" href="https://micro.blog/microsub" />
+<link rel="webmention" href="https://micro.blog/webmention" />
+<link rel="subscribe" href="https://micro.blog/users/follow" />
+
+{{ range .Site.Params.plugins_css }}
+  <link rel="stylesheet" href="{{ . }}" />
+{{ end }}
+
+{{ range $filename := .Site.Params.plugins_html }}
+  {{ partial $filename $ }}
+{{ end }}

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -1,39 +1,39 @@
 <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
-<link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
+<link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon">
 
 {{ range .AlternativeOutputFormats -}}
-  {{ printf `<link rel="%s" href="%s" type="%s" title="%s" />` .Rel .Permalink .MediaType.Type $.Site.Title | safeHTML }}
+  {{ printf `<link rel="%s" href="%s" type="%s" title="%s">` .Rel .Permalink .MediaType.Type $.Site.Title | safeHTML }}
 {{ end -}}
 
 {{ $podcastEpisodeCount := len (where .Site.Pages ".Params.audio" "!=" nil) }}
 {{ if gt $podcastEpisodeCount 0 }}
-  <link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast" />
+  <link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast">
 {{ end }}
 
-<link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
+<link rel="me" href="https://micro.blog/{{ .Site.Author.username }}">
 
 {{ with .Site.Params.twitter_username }}
-  <link rel="me" href="https://twitter.com/{{ . }}" />
+  <link rel="me" href="https://twitter.com/{{ . }}">
 {{ end }}
 
 {{ with .Site.Params.github_username }}
-  <link rel="me" href="https://github.com/{{ . }}" />
+  <link rel="me" href="https://github.com/{{ . }}">
 {{ end }}
 
 {{ with .Site.Params.instagram_username }}
-  <link rel="me" href="https://instagram.com/{{ . }}" />
+  <link rel="me" href="https://instagram.com/{{ . }}">
 {{ end }}
 
-<link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
-<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
-<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
-<link rel="micropub" href="https://micro.blog/micropub" />
-<link rel="microsub" href="https://micro.blog/microsub" />
-<link rel="webmention" href="https://micro.blog/webmention" />
-<link rel="subscribe" href="https://micro.blog/users/follow" />
+<link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}">
+<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth">
+<link rel="token_endpoint" href="https://micro.blog/indieauth/token">
+<link rel="micropub" href="https://micro.blog/micropub">
+<link rel="microsub" href="https://micro.blog/microsub">
+<link rel="webmention" href="https://micro.blog/webmention">
+<link rel="subscribe" href="https://micro.blog/users/follow">
 
 {{ range .Site.Params.plugins_css }}
-  <link rel="stylesheet" href="{{ . }}" />
+  <link rel="stylesheet" href="{{ . }}">
 {{ end }}
 
 {{ range $filename := .Site.Params.plugins_html }}

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -1,10 +1,8 @@
 <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
 <link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
 
-{{ $rsslink := .OutputFormats.Get "rss" }}
-{{ if $rsslink }}
-  <link rel="alternate" href="{{ $rsslink.Permalink }}" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link rel="alternate" href="{{ "feed.json" | absURL }}" type="application/json" title="{{ .Site.Title }}" />
+{{ range .AlternativeOutputFormats -}}
+  {{ printf `<link rel="%s" href="%s" type="%s" title="%s" />` .Rel .Permalink .MediaType.Type $.Site.Title | safeHTML }}
 {{ end -}}
 
 <link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast" />

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -7,7 +7,7 @@
   {{ printf `<link rel="%s" href="%s" type="%s" title="%s">` .Rel .Permalink .MediaType.Type $.Site.Title | safeHTML }}
 {{ end -}}
 
-{{ $podcastEpisodeCount := len (where .Site.Pages ".Params.audio" "!=" nil) }}
+{{ $podcastEpisodeCount := len (where .Site.Pages ".Params.audio_with_metadata" "!=" nil) }}
 {{ if gt $podcastEpisodeCount 0 }}
   <link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast">
   <link rel="alternate" href="{{ "podcast.json" | absURL }}" type="application/json" title="Podcast">

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -5,7 +5,10 @@
   {{ printf `<link rel="%s" href="%s" type="%s" title="%s" />` .Rel .Permalink .MediaType.Type $.Site.Title | safeHTML }}
 {{ end -}}
 
-<link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast" />
+{{ $podcastEpisodeCount := len (where .Site.Pages ".Params.audio" "!=" nil) }}
+{{ if gt $podcastEpisodeCount 0 }}
+  <link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast" />
+{{ end }}
 
 <link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
 

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -1,6 +1,3 @@
-<link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
-<link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon">
-
 {{ range .AlternativeOutputFormats -}}
   {{ printf `<link rel="%s" href="%s" type="%s" title="%s">` .Rel .Permalink .MediaType.Type $.Site.Title | safeHTML }}
 {{ end -}}
@@ -24,13 +21,16 @@
   <link rel="me" href="https://instagram.com/{{ . }}">
 {{ end }}
 
+<link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon">
 <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}">
 <link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth">
 <link rel="token_endpoint" href="https://micro.blog/indieauth/token">
+<link rel="subscribe" href="https://micro.blog/users/follow">
+<link rel="webmention" href="https://micro.blog/webmention">
 <link rel="micropub" href="https://micro.blog/micropub">
 <link rel="microsub" href="https://micro.blog/microsub">
-<link rel="webmention" href="https://micro.blog/webmention">
-<link rel="subscribe" href="https://micro.blog/users/follow">
+
+<link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
 
 {{ range .Site.Params.plugins_css }}
   <link rel="stylesheet" href="{{ . }}">

--- a/layouts/partials/microblog-head.html
+++ b/layouts/partials/microblog-head.html
@@ -10,7 +10,7 @@
 {{ $podcastEpisodeCount := len (where .Site.Pages ".Params.audio" "!=" nil) }}
 {{ if gt $podcastEpisodeCount 0 }}
   <link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast">
-  <link rel="alternate" href="{{ "podcast.json" | absURL }}" type="application/application/json" title="Podcast">
+  <link rel="alternate" href="{{ "podcast.json" | absURL }}" type="application/json" title="Podcast">
 {{ end }}
 
 <link rel="me" href="https://micro.blog/{{ .Site.Author.username }}">


### PR DESCRIPTION
As the title suggests, this pull request extracts common Micro.blog head elements into a partial and makes sure that they are compatible with Hugo 0.117.

I extracted the Micro.blog specific head elements from the Marfa theme and then glanced over the other official themes to look for discrepancies. So there's [a companion pull request in the theme-marfa repository](https://github.com/microdotblog/theme-marfa/pull/11) where all the common elements are replaced by the inclusion of the partial introduced here.

Okay, onward to some notes on changes and potential problems…

## Potential "breaking" stuff affecting all themes

Until now, the podcast feed was always present in head, even if there were no episodes published. I've changed that behavior to only include the feed when there is at least one episode published.

Also, I added a missing reference to the `podcast.json` file.

Today, when one visits a category page like https://www.manton.org/categories/coffee/ the head includes a reference to the corresponding RSS feed, as one might expect. The JSON feed, however, points to the main feed ("home feed"). This pull request changes that.

Speaking about podcast feeds, the layouts use different ways to identify podcast posts. The JSON version uses `.Params.audio` while the RSS version uses `.Params.audio_with_metadata`. Is this intentional, @manton, or should we change this?

The `EditURI` link element is now always present. Previously, it was only there if there was an RSS feed present in the head. On the homepage and category pages, for example, but not on other pages.

I removed the reference to `.RSSLink` (that no longer exist) to get blogs building on Hugo 0.117.

## Potential "breaking" stuff in *some* themes

Today, the custom stylesheet is cache busted only in some themes. With this pull request, it will always be busted using `{{ .Site.Params.theme_seconds }}`. Let me know if this is what you want, @manton.

On the subject of stylesheets, it's worth thinking about cascading and the order of elements in the partial.

As most of the stuff in the common Micro.blog head is metadata, how we order the HTML is mostly a question of taste. With a few exceptions: `custom.css`, CSS files provided by plug-ins, and HTML provided by plug-ins. I've kept the order from the Marfa theme: `custom.css` first, followed by plug-in CSS files and then plug-in HTML.

Some themes might potentially include this stuff in another order today, but the ones I've checked look okay.

Where each theme chooses to include the `microblog-head.html` partial will also matter. I guess including it right before  `</head>` makes the most sense. That will make it likely that `custom.css` is included and applied after theme-specific styling.

## Category feeds and taxonomies

Let's talk about categories and feeds. [The documentation](https://help.micro.blog/t/feeds/94) only mentions one such feed: 

> https://username.micro.blog/categories/my-category/feed.xml – Posts from a specific category on a blog.

Nice, this works. Here's a real-world example: https://www.manton.org/categories/coffee/feed.xml.

There's no mention of a JSON feed, but looking at the default `config.json`, we see [it's intended that such a feed should exist](https://github.com/microdotblog/theme-blank/blob/master/config.json#L59). It doesn't, however. Fetching:

https://www.manton.org/categories/coffee/feed.json

returns a 404. That's because there was no layout available to handle it. From Hugo's build log:

> **WARN** found no layout file for "json" for kind "taxonomy": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.

But now there is! So, the example above works with this pull request. As does:

https://www.manton.org/categories/feed.xml  
https://www.manton.org/categories/feed.json

to get a list of categories in feed format. The RSS variant was already working, but not the JSON one because of the missing layout file.

Maybe you didn't indent for all these different feeds to exist, @manton, and if that's the case, I can revert the relevant commits and change `config.json` to match the output formats you want to be available.

I also removed the depracted `taxonomyTerm` from `config.json`.

## What now?

Here's how I suggest we go from here.

1. I would love to get some feedback on this pull request. Am I on the right track? Something missing? Or is there anything that should not be here? Is `microblog-head.html` good or should we name the partial differently? 
2. I make changes based on the feedback.
3. We make Marfa use this new partial and roll it out to production.
4. When we are reasonably sure I didn't break anything, I will go forth and update the rest of the built-in themes.
5. We let third-party developers know that this partial is a thing and that they should use it for their convenience and future Micro.blog compatibility.