### PR TITLE
Make podcast RSS validate

### DIFF
--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -28,8 +28,6 @@
 				{{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
 				<guid isPermaLink="true">{{ .Permalink }}</guid>
 				<description>{{ .Content | html }}</description>
-				<itunes:subtitle>{{ .Content | html }}</itunes:subtitle>
-				<itunes:summary>{{ .Content | html }}</itunes:summary>
 				{{ range first 1 .Params.audio_with_metadata }}
 					{{ if gt .size 0 }}
 						<enclosure url="{{ .url }}" type="audio/mpeg" length="{{ .size }}"></enclosure>

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
 	<channel>
+		<atom:link href="{{ absURL "podcast.xml" }}" rel="self" type="application/rss+xml" />
 		<title>{{ if eq .Title .Site.Title }}{{ .Site.Title | htmlEscape }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title | htmlEscape }}{{ end }}</title>
 		<link>{{ .Permalink }}</link>
 		<description>{{ .Site.Params.itunes_description | htmlEscape }}</description>

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -11,7 +11,7 @@
 			<itunes:category text="{{ .Site.Params.itunes_subcategory | htmlEscape }}"></itunes:category>
 		</itunes:category>
 		<itunes:author>{{ .Site.Params.itunes_author | htmlEscape }}</itunes:author>
-		<itunes:explicit>no</itunes:explicit>
+		<itunes:explicit>false</itunes:explicit>
 		<itunes:owner>
 			<itunes:name>{{ .Site.Params.itunes_author | htmlEscape }}</itunes:name>
 			<itunes:email>{{ .Site.Params.itunes_email | htmlEscape }}</itunes:email>

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -1,43 +1,43 @@
 <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
-  <channel>
-    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <link>{{ .Permalink }}</link>
-    <description>{{ .Site.Params.itunes_description }}</description>
-    <copyright>Copyright {{ .Date.Format "2006" }} {{ .Site.Params.itunes_author | htmlEscape }}</copyright>
+	<channel>
+		<title>{{ if eq	.Title	.Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+		<link>{{ .Permalink }}</link>
+		<description>{{ .Site.Params.itunes_description }}</description>
+		<copyright>Copyright {{ .Date.Format "2006" }} {{ .Site.Params.itunes_author | htmlEscape }}</copyright>
 	<itunes:image href="{{ .Site.Params.itunes_cover }}" />
 	<itunes:category text="{{ .Site.Params.itunes_category | htmlEscape }}">
 		<itunes:category text="{{ .Site.Params.itunes_subcategory | htmlEscape }}"></itunes:category>
 	</itunes:category>
 	<itunes:author>{{ .Site.Params.itunes_author | htmlEscape }}</itunes:author>
-	<itunes:explicit>no</itunes:explicit>		
+	<itunes:explicit>no</itunes:explicit>
 	<itunes:owner>
 		<itunes:name>{{ .Site.Params.itunes_author | htmlEscape }}</itunes:name>
 		<itunes:email>{{ .Site.Params.itunes_email | htmlEscape }}</itunes:email>
 	</itunes:owner>
-    {{ with .Site.LanguageCode }}
-    <language>{{.}}</language>
-    {{ end }}
-    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
-	{{- $list := where .Site.Pages ".Params.audio_with_metadata" "!=" nil -}}
-    {{ range $list }}
-    <item>
-      <title>{{ .Title | html }}</title>
-      <link>{{ .Permalink }}</link>
-      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
-      <guid isPermaLink="true">{{ .Permalink }}</guid>
-      <description>{{ .Content | html }}</description>
-      <itunes:subtitle>{{ .Content | html }}</itunes:subtitle>
-      <itunes:summary>{{ .Content | html }}</itunes:summary>
-		{{ range first 1 .Params.audio_with_metadata }}
-      {{ if gt .size 0 }}
-			  <enclosure url="{{ .url }}" type="audio/mpeg" length="{{ .size }}"></enclosure>
-        <itunes:duration>{{ .duration_seconds }}</itunes:duration>
-      {{ else }}
-        <enclosure url="{{ .url }}" type="audio/mpeg"></enclosure>
-      {{ end }}
+		{{ with .Site.LanguageCode }}
+		<language>{{.}}</language>
 		{{ end }}
-    </item>
-    {{ end }}
-  </channel>
+		<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+	{{- $list := where .Site.Pages ".Params.audio_with_metadata" "!=" nil -}}
+		{{ range $list }}
+		<item>
+			<title>{{ .Title | html }}</title>
+			<link>{{ .Permalink }}</link>
+			<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+			{{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+			<guid isPermaLink="true">{{ .Permalink }}</guid>
+			<description>{{ .Content | html }}</description>
+			<itunes:subtitle>{{ .Content | html }}</itunes:subtitle>
+			<itunes:summary>{{ .Content | html }}</itunes:summary>
+		{{ range first 1 .Params.audio_with_metadata }}
+			{{ if gt .size 0 }}
+				<enclosure url="{{ .url }}" type="audio/mpeg" length="{{ .size }}"></enclosure>
+				<itunes:duration>{{ .duration_seconds }}</itunes:duration>
+			{{ else }}
+				<enclosure url="{{ .url }}" type="audio/mpeg"></enclosure>
+			{{ end }}
+		{{ end }}
+		</item>
+		{{ end }}
+	</channel>
 </rss>

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -27,7 +27,7 @@
 				<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
 				{{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
 				<guid isPermaLink="true">{{ .Permalink }}</guid>
-				<description>{{ .Content | html }}</description>
+				<description><![CDATA[{{ .Content }}]]></description>
 				{{ range first 1 .Params.audio_with_metadata }}
 					{{ if gt .size 0 }}
 						<enclosure url="{{ .url }}" type="audio/mpeg" length="{{ .size }}"></enclosure>

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
 	<channel>
 		<title>{{ if eq .Title .Site.Title }}{{ .Site.Title | htmlEscape }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title | htmlEscape }}{{ end }}</title>
 		<link>{{ .Permalink }}</link>

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
 	<channel>
-		<title>{{ if eq	.Title	.Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+		<title>{{ if eq .Title .Site.Title }}{{ .Site.Title | htmlEscape }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title | htmlEscape }}{{ end }}</title>
 		<link>{{ .Permalink }}</link>
-		<description>{{ .Site.Params.itunes_description }}</description>
+		<description>{{ .Site.Params.itunes_description | htmlEscape }}</description>
 		<copyright>Copyright {{ .Date.Format "2006" }} {{ .Site.Params.itunes_author | htmlEscape }}</copyright>
 		<itunes:image href="{{ .Site.Params.itunes_cover }}" />
 		<itunes:category text="{{ .Site.Params.itunes_category | htmlEscape }}">
@@ -22,10 +22,10 @@
 		{{- $list := where .Site.Pages ".Params.audio_with_metadata" "!=" nil -}}
 		{{ range $list }}
 			<item>
-				<title>{{ .Title | html }}</title>
+				<title>{{ .Title | htmlEscape }}</title>
 				<link>{{ .Permalink }}</link>
 				<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-				{{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+				{{ with .Site.Author.email }}<author>{{ . | htmlEscape}}{{ with $.Site.Author.name }} ({{ . | htmlEscape}}){{end}}</author>{{end}}
 				<guid isPermaLink="true">{{ .Permalink }}</guid>
 				<description><![CDATA[{{ .Content }}]]></description>
 				{{ range first 1 .Params.audio_with_metadata }}

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -4,40 +4,40 @@
 		<link>{{ .Permalink }}</link>
 		<description>{{ .Site.Params.itunes_description }}</description>
 		<copyright>Copyright {{ .Date.Format "2006" }} {{ .Site.Params.itunes_author | htmlEscape }}</copyright>
-	<itunes:image href="{{ .Site.Params.itunes_cover }}" />
-	<itunes:category text="{{ .Site.Params.itunes_category | htmlEscape }}">
-		<itunes:category text="{{ .Site.Params.itunes_subcategory | htmlEscape }}"></itunes:category>
-	</itunes:category>
-	<itunes:author>{{ .Site.Params.itunes_author | htmlEscape }}</itunes:author>
-	<itunes:explicit>no</itunes:explicit>
-	<itunes:owner>
-		<itunes:name>{{ .Site.Params.itunes_author | htmlEscape }}</itunes:name>
-		<itunes:email>{{ .Site.Params.itunes_email | htmlEscape }}</itunes:email>
-	</itunes:owner>
+		<itunes:image href="{{ .Site.Params.itunes_cover }}" />
+		<itunes:category text="{{ .Site.Params.itunes_category | htmlEscape }}">
+			<itunes:category text="{{ .Site.Params.itunes_subcategory | htmlEscape }}"></itunes:category>
+		</itunes:category>
+		<itunes:author>{{ .Site.Params.itunes_author | htmlEscape }}</itunes:author>
+		<itunes:explicit>no</itunes:explicit>
+		<itunes:owner>
+			<itunes:name>{{ .Site.Params.itunes_author | htmlEscape }}</itunes:name>
+			<itunes:email>{{ .Site.Params.itunes_email | htmlEscape }}</itunes:email>
+		</itunes:owner>
 		{{ with .Site.LanguageCode }}
-		<language>{{.}}</language>
+			<language>{{.}}</language>
 		{{ end }}
 		<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
-	{{- $list := where .Site.Pages ".Params.audio_with_metadata" "!=" nil -}}
+		{{- $list := where .Site.Pages ".Params.audio_with_metadata" "!=" nil -}}
 		{{ range $list }}
-		<item>
-			<title>{{ .Title | html }}</title>
-			<link>{{ .Permalink }}</link>
-			<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-			{{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
-			<guid isPermaLink="true">{{ .Permalink }}</guid>
-			<description>{{ .Content | html }}</description>
-			<itunes:subtitle>{{ .Content | html }}</itunes:subtitle>
-			<itunes:summary>{{ .Content | html }}</itunes:summary>
-		{{ range first 1 .Params.audio_with_metadata }}
-			{{ if gt .size 0 }}
-				<enclosure url="{{ .url }}" type="audio/mpeg" length="{{ .size }}"></enclosure>
-				<itunes:duration>{{ .duration_seconds }}</itunes:duration>
-			{{ else }}
-				<enclosure url="{{ .url }}" type="audio/mpeg"></enclosure>
-			{{ end }}
-		{{ end }}
-		</item>
+			<item>
+				<title>{{ .Title | html }}</title>
+				<link>{{ .Permalink }}</link>
+				<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+				{{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+				<guid isPermaLink="true">{{ .Permalink }}</guid>
+				<description>{{ .Content | html }}</description>
+				<itunes:subtitle>{{ .Content | html }}</itunes:subtitle>
+				<itunes:summary>{{ .Content | html }}</itunes:summary>
+				{{ range first 1 .Params.audio_with_metadata }}
+					{{ if gt .size 0 }}
+						<enclosure url="{{ .url }}" type="audio/mpeg" length="{{ .size }}"></enclosure>
+						<itunes:duration>{{ .duration_seconds }}</itunes:duration>
+					{{ else }}
+						<enclosure url="{{ .url }}" type="audio/mpeg"></enclosure>
+					{{ end }}
+				{{ end }}
+			</item>
 		{{ end }}
 	</channel>
 </rss>

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -1,4 +1,5 @@
-<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
 	<channel>
 		<title>{{ if eq	.Title	.Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
 		<link>{{ .Permalink }}</link>


### PR DESCRIPTION
This pull request tweaks the podcast.xml layout to pass validation with the following services:

[W3C Feed Validation Service](https://validator.w3.org/feed/)
[Podbase Podcast Validator](https://podba.se/validate/)
[Cast Feed Validator](https://www.castfeedvalidator.com/)

For this work, I've referred to:

* Apple's [A Podcaster’s Guide to RSS](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) (their specification for the `itunes` namespace).
* [RSS 2.0 Specification](https://www.rssboard.org/rss-specification).
* [The Podcast Standards Project](https://podstandards.org) and their [proposed podcast RSS standard](https://github.com/Podcast-Standards-Project/PSP-1-Podcast-RSS-Specification).

An actual feed that uses this new layout is currently available here: [https://dahlstrand.net/podcast.xml](https://dahlstrand.net/podcast.xml). I've tested it with the validators mentioned above, Apple Podcasts, and Overcast.

This layout was hard to read because the indentation was alternating between spaces and tabs. The first two commits fix that, with the unfortunate effect that it looks like every row has changed in the diff for this pull request. [Here's a better version](https://github.com/svendahlstrand/theme-blank/compare/6bb5543317b7cb1a20c55deca68b0e9a5f7c1c48...valid-podcast-rss). 👀

Also, @manton, I decided to change from `no` to `false` in the end. [Read my motivation for it here](https://github.com/svendahlstrand/theme-blank/commit/5b1008dc34d180e49caf3fdbc17a24374158f872). But, of course, you decide. Please let me know if you want me to revert that commit.