### PR TITLE
Update index.json to include date_modified

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -23,6 +23,7 @@
 				{{- $s := replace $s "\\u0026" "&" }}
 				"content_html": {{ $s }},
 				"date_published": "{{ .Date.Format "2006-01-02T15:04:05-07:00" }}",
+		                "date_modified": "{{ .Lastmod | time.Format  "2006-01-02T15:04:05-07:00" }}",
 				"url": "{{ .Permalink }}"
 				{{- with .Params.categories -}}
 				,


### PR DESCRIPTION
This uses Hugo's [.Lastmod](https://gohugo.io/methods/page/lastmod/) to add the optional property of JSON Feed 1.1 [date_modified](https://www.jsonfeed.org/version/1.1/) based on [Rick Cogley's request](https://help.micro.blog/t/add-date-updated-to-feed-json/2267/2).