### PR TITLE
Use the new has_podcasts parameter

### DIFF
--- a/layouts/partials/microblog_head.html
+++ b/layouts/partials/microblog_head.html
@@ -7,8 +7,7 @@
   {{ printf `<link rel="%s" href="%s" type="%s" title="%s">` .Rel .Permalink .MediaType.Type $.Site.Title | safeHTML }}
 {{ end -}}
 
-{{ $podcastEpisodeCount := len (where .Site.Pages ".Params.audio_with_metadata" "!=" nil) }}
-{{ if gt $podcastEpisodeCount 0 }}
+{{ if .Site.Params.has_podcasts }}
   <link rel="alternate" href="{{ "podcast.xml" | absURL }}" type="application/rss+xml" title="Podcast">
   <link rel="alternate" href="{{ "podcast.json" | absURL }}" type="application/json" title="Podcast">
 {{ end }}


### PR DESCRIPTION
Let's use the new `has_podcasts` parameter to get rid of the unnecessary counting of podcasts episodes for every page built. This should make site builds a lot faster and resolve issue #9.

I've tested this change locally on my machine, and it works well with the Marfa theme. As it's just a simple boolean check, I can't imagine it will cause trouble with other themes.