### PR TITLE
Better support for Hugo 0.158

### DIFF
--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -18,7 +18,7 @@
 				{{ if .Title }}
 					<span class="p-name"><b>{{ .Title }}</b></span> 
 				{{ end }}
-				<span class="p-summary">{{ .Summary | plainify | truncate 100 }}</span>
+				<span class="p-summary">{{ .Summary | plainify | htmlUnescape | truncate 100 }}</span>
 			</p>
 			
 		{{ end }}

--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -18,7 +18,7 @@
 				{{ if .Title }}
 					<span class="p-name"><b>{{ .Title }}</b></span> 
 				{{ end }}
-				<span class="p-summary">{{ .Summary | truncate 100 }}</span>
+				<span class="p-summary">{{ .Summary | plainify | truncate 100 }}</span>
 			</p>
 			
 		{{ end }}

--- a/layouts/_default/list.json.json
+++ b/layouts/_default/list.json.json
@@ -1,7 +1,7 @@
 {
   "version": "https://jsonfeed.org/version/1",
   "title": {{ if eq  .Title  .Site.Title }}{{ .Site.Title | jsonify }}{{ else }}{{ printf `%s on %s` .Title .Site.Title | jsonify }}{{ end }},
-  "icon": "{{ .Site.Author.avatar }}",
+  "icon": "{{ .Site.Params.author.avatar }}",
   "home_page_url": "{{ .Site.BaseURL }}",
   "feed_url": "{{ .Site.BaseURL }}feed.json",
   "items": [

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -12,7 +12,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       {{- if .Params.guid }}
       <guid>{{ .Params.guid }}</guid>
       {{- else -}}

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,7 +1,7 @@
 {
 	"version": "https://jsonfeed.org/version/1",
 	"title": {{ .Site.Title | jsonify }},
-	"icon": "{{ .Site.Author.avatar }}",
+	"icon": "{{ .Site.Params.author.avatar }}",
 	"home_page_url": "{{ .Site.BaseURL }}",
 	"feed_url": "{{ .Site.BaseURL }}feed.json",
 	"items": [

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -22,7 +22,7 @@
 				{{- $s := replace $s "\\u003e" ">" -}}
 				{{- $s := replace $s "\\u0026" "&" }}
 				"content_html": {{ $s }},
-				{{ if .Params.custom_summary }}"summary": {{ .Summary | plainify | jsonify }},{{ end }}
+				{{ if .Params.custom_summary }}"summary": {{ .Summary | plainify | htmlUnescape | jsonify }},{{ end }}
 				"date_published": "{{ .Date.Format "2006-01-02T15:04:05-07:00" }}",
 				"url": "{{ .Permalink }}"
 				{{- with .Params.categories -}}

--- a/layouts/index.xml
+++ b/layouts/index.xml
@@ -13,7 +13,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       {{- if .Params.guid }}
       <guid>{{ .Params.guid }}</guid>
       {{- else -}}

--- a/layouts/list.archivehtml.html
+++ b/layouts/list.archivehtml.html
@@ -18,7 +18,7 @@
 				{{ if .Title }}
 					<span class="p-name"><b>{{ .Title }}</b></span> 
 				{{ end }}
-				<span class="p-summary">{{ .Summary | plainify | truncate 100 }}</span>
+				<span class="p-summary">{{ .Summary | plainify | htmlUnescape | truncate 100 }}</span>
 			</p>
 			
 		{{ end }}

--- a/layouts/list.archivehtml.html
+++ b/layouts/list.archivehtml.html
@@ -18,7 +18,7 @@
 				{{ if .Title }}
 					<span class="p-name"><b>{{ .Title }}</b></span> 
 				{{ end }}
-				<span class="p-summary">{{ .Summary | truncate 100 }}</span>
+				<span class="p-summary">{{ .Summary | plainify | truncate 100 }}</span>
 			</p>
 			
 		{{ end }}

--- a/layouts/list.archivejson.json
+++ b/layouts/list.archivejson.json
@@ -1,7 +1,7 @@
 {
 	"version": "https://jsonfeed.org/version/1",
 	"title": {{ .Site.Title | jsonify }},
-	"icon": "{{ .Site.Author.avatar }}",
+	"icon": "{{ .Site.Params.author.avatar }}",
 	"home_page_url": "{{ .Site.BaseURL }}",
 	"feed_url": "{{ .Site.BaseURL }}photos/index.json",
 	"items": [

--- a/layouts/list.archivejson.json
+++ b/layouts/list.archivejson.json
@@ -11,7 +11,7 @@
 			{
 				"id": "{{ .Permalink }}",
 				"title": {{ .Title | jsonify }},
-				"content_text": {{ .Summary | plainify | truncate 100 | jsonify }},
+				"content_text": {{ .Summary | plainify | htmlUnescape | truncate 100 | jsonify }},
 				"date_published": "{{ .Date.Format "2006-01-02T15:04:05-07:00" }}",
 				"url": "{{ .Permalink }}"
 			}

--- a/layouts/list.archivejson.json
+++ b/layouts/list.archivejson.json
@@ -11,7 +11,7 @@
 			{
 				"id": "{{ .Permalink }}",
 				"title": {{ .Title | jsonify }},
-				"content_text": {{ .Summary | truncate 100 | jsonify }},
+				"content_text": {{ .Summary | plainify | truncate 100 | jsonify }},
 				"date_published": "{{ .Date.Format "2006-01-02T15:04:05-07:00" }}",
 				"url": "{{ .Permalink }}"
 			}

--- a/layouts/list.photosjson.json
+++ b/layouts/list.photosjson.json
@@ -1,7 +1,7 @@
 {
 	"version": "https://jsonfeed.org/version/1",
 	"title": {{ .Site.Title | jsonify }},
-	"icon": "{{ .Site.Author.avatar }}",
+	"icon": "{{ .Site.Params.author.avatar }}",
 	"home_page_url": "{{ .Site.BaseURL }}",
 	"feed_url": "{{ .Site.BaseURL }}photos/index.json",
 	"items": [

--- a/layouts/list.podcastjson.json
+++ b/layouts/list.podcastjson.json
@@ -1,7 +1,7 @@
 {
 	"version": "https://jsonfeed.org/version/1",
 	"title": {{ .Site.Title | jsonify }},
-	"icon": "{{ .Site.Author.avatar }}",
+	"icon": "{{ .Site.Params.author.avatar }}",
 	"home_page_url": "{{ .Site.BaseURL }}",
 	"feed_url": "{{ .Site.BaseURL }}podcast.json",
 	"_podcast": {

--- a/layouts/list.podcastxml.xml
+++ b/layouts/list.podcastxml.xml
@@ -26,7 +26,7 @@
 				<title>{{ .Title | htmlEscape }}</title>
 				<link>{{ .Permalink }}</link>
 				<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-				{{ with .Site.Author.email }}<author>{{ . | htmlEscape}}{{ with $.Site.Author.name }} ({{ . | htmlEscape}}){{end}}</author>{{end}}
+				{{ with .Site.Params.author.email }}<author>{{ . | htmlEscape}}{{ with $.Site.Params.author.name }} ({{ . | htmlEscape}}){{end}}</author>{{end}}
 				<guid isPermaLink="true">{{ .Permalink }}</guid>
 				<description><![CDATA[{{ .Content }}]]></description>
 				{{ range first 1 .Params.audio_with_metadata }}

--- a/layouts/newsletter.html
+++ b/layouts/newsletter.html
@@ -14,7 +14,7 @@
 <div class="microblog_email">
 
 	<p class="microblog_header">
-	<img src="{{ .Site.Author.avatar }}" width="30" height="30" alt="Profile icon" style="border-radius: 15px; vertical-align: middle;">
+	<img src="{{ .Site.Params.author.avatar }}" width="30" height="30" alt="Profile icon" style="border-radius: 15px; vertical-align: middle;">
 	<b>{{ .Site.Title }}</b>
 	— <a href="{{ .Footer.UnsubscribeURL }}">Unsubscribe</a>
 


### PR DESCRIPTION
There have been two breaking changes in Hugo, and this pull request addresses both of them.

[Starting with Hugo 0.134](https://github.com/gohugoio/hugo/releases/tag/v0.134.0), `.Summary` now returns HTML instead of plain text, which affects the archive page and a couple of JSON files that expect plain text. I've solved the issue by using `plainify` and `htmlUnescape` (to maintain compatibility with Hugo 0.91).

[In Hugo 0.156](https://github.com/gohugoio/hugo/releases/tag/v0.156.0), `.Site.Author` was removed and @manton has introduced `.Site.Params.author` for us to use instead (in commit 53f5adf). I've replaced all remaining occurrences in theme-blank.

This wasn't strictly necessary since Micro.blog helpfully updates old usage. It's mainly a cosmetic and educational change, making it clear to theme & plugin developers that `.Site.Params.author` is the correct option to use from now on.

These changes have been tested locally on my machine, and confirmed working on Hugo 0.91 and 0.158. Would love for you to test and confirm too, @manton.

